### PR TITLE
feat: add aws_event and aws_context to each log if the configuration enable it

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "4571:4571"
       - "127.0.0.1:4510-4559:4510-4559" # external services port range
     environment:
-      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?} # required for Pro version
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:-} # required for Pro version
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       - DEBUG=${DEBUG:-0}
       - SERVICES=apigateway,lambda,iam,logs,cloudwatch,dynamodb

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "deploy:lambda": "yarn workspace @project/lambda run build:deploy",
     "start:www": "yarn workspace @project/www run start",
     "start:lambda": "concurrently \"yarn start:docker\" \"yarn workspace @project/lambda run start\" --names docker,esbuild -c green,blue",
-    "start:docker": "dotenv-flow docker compose up",
+    "start:docker": "dotenv-flow docker compose up -- -d",
     "stop:docker": "docker compose down",
     "test": "vitest run",
     "test:watch": "vitest run",

--- a/packages/infra/aws/log-request/ServerlessLogRequest.ts
+++ b/packages/infra/aws/log-request/ServerlessLogRequest.ts
@@ -50,7 +50,6 @@ export class ServerlessLogRequest {
 
     if (logEnd) {
       if ($ctx.response.statusCode >= 400) {
-        console.log("===>", $ctx.error)
         $ctx.logger.error({
           event: "request.end",
           status: $ctx.response.statusCode,
@@ -118,7 +117,9 @@ export class ServerlessLogRequest {
       headers: request.headers,
       body: request.body,
       query: request.query,
-      params: request.params
+      params: request.params,
+      aws_event: ctx.event,
+      aws_context: ctx.context
     }
   }
 

--- a/packages/lambda/src/auth/handler.ts
+++ b/packages/lambda/src/auth/handler.ts
@@ -7,6 +7,10 @@ import { PlatformServerless } from "@tsed/platform-serverless"
 // shared configuration
 const config = {
   envs: process.env,
+  logger: {
+    level: "info" as never,
+    requestFields: ["reqId", "method", "url", "duration", "route", "aws_event", "aws_context"]
+  },
   auth: {
     // Not applicable here because lambda are packaged and deployed on AWS.
     // For this reason, we can't use the file system to store data (prefer S3, DynamoDB, etc.)

--- a/packages/lambda/src/timeslots/handler.ts
+++ b/packages/lambda/src/timeslots/handler.ts
@@ -11,7 +11,8 @@ const config = {
   envs: process.env,
   lambda: [TimeslotsController],
   logger: {
-    level: "info" as never
+    level: "info" as never,
+    requestFields: ["reqId", "method", "url", "duration", "route", "aws_event", "aws_context"]
   },
   timeslots: {
     // Not applicable here because lambda are packaged and deployed on AWS.


### PR DESCRIPTION
This PR add aws_event and aws_context to each request when the lambda add the following configuration:

```diff

const config = {
  envs: process.env,
+  logger: {
+    level: "info" as never,
+    requestFields: ["reqId", "method", "url", "duration", "route", "aws_event", "aws_context"]
+  },
  auth: {
    // Not applicable here because lambda are packaged and deployed on AWS.
    // For this reason, we can't use the file system to store data (prefer S3, DynamoDB, etc.)
    // dbFilePath: join(import.meta.dirname, "../../../../.tmp/timeslots.json")
  }
}
```